### PR TITLE
SHEDDWEB-1253 - Update deploys to send to Teams

### DIFF
--- a/lib/viget/deployment/common.rb
+++ b/lib/viget/deployment/common.rb
@@ -25,4 +25,5 @@ require 'capistrano/ext/multistage'
 require 'bundler/capistrano'
 
 require 'viget/deployment/shared/slack_notification'
+require 'viget/deployment/shared/deploy_notification'
 require 'viget/deployment/shared/maintenance'

--- a/lib/viget/deployment/common.rb
+++ b/lib/viget/deployment/common.rb
@@ -24,6 +24,6 @@ end
 require 'capistrano/ext/multistage'
 require 'bundler/capistrano'
 
-require 'viget/deployment/shared/slack_notification'
+# require 'viget/deployment/shared/slack_notification'
 require 'viget/deployment/shared/deploy_notification'
 require 'viget/deployment/shared/maintenance'

--- a/lib/viget/deployment/deploy_notifier.rb
+++ b/lib/viget/deployment/deploy_notifier.rb
@@ -18,21 +18,21 @@ module Viget
 
       def payload
         {
-          "title": app_username, #<Environment> deploy
-          "sections": [{
-            "title": "[#{current_revision}](#{commit_url})", #revision number link to commit in github
-            "text": commit_message, #commit message from git
-            "facts": [{
-                        "name": "Deployed By", #header
-                        "value": user, #deployer
-                      }, {
-                        "name": "Branch", #header
-                        "value": "[#{branch_url}](#{branch})", #branch name link to branch in github
-                      }, {
-                        "name": "URL", #header
-                        "value": app_url, #environment url
-                      }]
-          }]
+          title: "#{app_emoji} #{environment} Deploy",
+          text: "[#{current_revision}](#{commit_url})",
+          sections: [{
+                         title: commit_message,
+                         facts: [{
+                                     name: "Deployed By",
+                                     value: user,
+                                   }, {
+                                     name: "Branch",
+                                     value: "[#{branch_url}](#{branch})",
+                                   }, {
+                                     name: "URL",
+                                     value: app_url,
+                                   }]
+                       }]
         }
       end
 
@@ -53,21 +53,6 @@ module Viget
       def app_url
         cap.fetch(:app_url, nil)
       end
-
-      # def color
-      #   case environment
-      #   when 'Integration'
-      #     '#d16d4e'
-      #   when 'Staging'
-      #     '#7c82d1'
-      #   else
-      #     '#23d15a'
-      #   end
-      # end
-
-      # def fallback
-      #   "#{current_revision}: #{commit_message}"
-      # end
 
       def environment
         cap.fetch(:stage).to_s.split('_').map(&:capitalize).join(' ')
@@ -116,21 +101,11 @@ module Viget
         http = Net::HTTP.new(app_uri.host, app_uri.port)
         http.use_ssl = true
 
-        request = Net::HTTP::Post.new(app_uri.request_uri)
-        request.set_form_data(payload: JSON.generate(payload))
+        request = Net::HTTP::Post.new(app_uri.request_uri, {'Content-Type' =>'application/json'})
+        request.body = payload.to_json
 
         http.request(request)
       end
-
-      # def clean(thinger)
-      #   opts = {
-      #     invalid: :replace,
-      #     undef:   :replace,
-      #     replace: ''
-      #   }
-      #
-      #   thinger.encode(Encoding.find('ASCII'), opts)
-      # end
 
     end
   end

--- a/lib/viget/deployment/deploy_notifier.rb
+++ b/lib/viget/deployment/deploy_notifier.rb
@@ -18,21 +18,15 @@ module Viget
 
       def payload
         {
-          title: "#{app_emoji} #{environment} Deploy",
-          text: "[#{current_revision}](#{commit_url})",
-          sections: [{
-                         title: commit_message,
-                         facts: [{
-                                     name: "Deployed By",
-                                     value: user,
-                                   }, {
-                                     name: "Branch",
-                                     value: "[#{branch_url}](#{branch})",
-                                   }, {
-                                     name: "URL",
-                                     value: app_url,
-                                   }]
-                       }]
+          emoji: app_emoji,
+          environment: environment,
+          currentRevision: current_revision,
+          commitURL: commit_url,
+          commitMessage: commit_message,
+          user: user,
+          branch: branch,
+          branchURL: branch_url,
+          environmentURL: app_url
         }
       end
 
@@ -47,7 +41,7 @@ module Viget
       end
 
       def app_emoji
-        cap.fetch(:app_emoji, '(bell)')
+        cap.fetch(:app_emoji, '2705')
       end
 
       def app_url

--- a/lib/viget/deployment/deploy_notifier.rb
+++ b/lib/viget/deployment/deploy_notifier.rb
@@ -1,0 +1,138 @@
+require 'net/http'
+require 'uri'
+require 'json'
+
+module Viget
+  module Deployment
+    class DeployNotifier
+      attr_reader :cap, :deploy_notification_url, :deploy_notification_channel
+
+      def initialize(cap, deploy_notification_url, deploy_notification_channel)
+        @cap = cap
+        @deploy_notification_url = deploy_notification_url
+        @deploy_notification_channel = deploy_notification_channel
+      end
+
+      def notify
+        post(payload)
+      end
+
+      def payload
+        {
+          "title": app_username, #<Environment> deploy
+          "sections": [{
+            "title": "[#{current_revision}](#{commit_url})", #revision number link to commit in github
+            "text": commit_message, #commit message from git
+            "facts": [{
+                        "name": "Deployed By", #header
+                        "value": user, #deployer
+                      }, {
+                        "name": "Branch", #header
+                        "value": "[#{branch_url}](#{branch})", #branch name link to branch in github
+                      }, {
+                        "name": "URL", #header
+                        "value": app_url, #environment url
+                      }]
+          }]
+        }
+      end
+
+      private
+
+      def app_uri
+        URI.parse(deploy_notification_url)
+      end
+
+      def app_username
+        cap.fetch(:app_username, "#{app_emoji} #{environment} Deploy")
+      end
+
+      def app_emoji
+        cap.fetch(:app_emoji, '(bell)')
+      end
+
+      def app_url
+        cap.fetch(:app_url, nil)
+      end
+
+      # def color
+      #   case environment
+      #   when 'Integration'
+      #     '#d16d4e'
+      #   when 'Staging'
+      #     '#7c82d1'
+      #   else
+      #     '#23d15a'
+      #   end
+      # end
+
+      # def fallback
+      #   "#{current_revision}: #{commit_message}"
+      # end
+
+      def environment
+        cap.fetch(:stage).to_s.split('_').map(&:capitalize).join(' ')
+      end
+
+      def git_username
+        username = cap.run_locally('git config --get user.name')
+
+        username unless username.nil? or username == ''
+      end
+
+      def user
+        git_username || ENV['USER']
+      end
+
+      def github_url
+        repository_url = cap.fetch(:repository)
+        path           = repository_url.gsub(%r{(^git@github\.com:?|\.git$)}, '')
+
+        "https://github.com/#{path}"
+      end
+
+      def branch_url
+        branch = cap.fetch(:branch).to_s.split('/').last
+
+        "#{github_url}/commits/#{branch}"
+      end
+
+      def commit_url
+        "#{github_url}/commit/#{current_revision}"
+      end
+
+      def commit_message
+        @commit_message ||= cap.capture(%{cd #{cap.current_path}; git show --pretty=format:"%s - %an" HEAD | head -n 1}).strip
+      end
+
+      def current_revision
+        cap.current_revision
+      end
+
+      def branch
+        cap.fetch(:branch)
+      end
+
+      def post(payload)
+        http = Net::HTTP.new(app_uri.host, app_uri.port)
+        http.use_ssl = true
+
+        request = Net::HTTP::Post.new(app_uri.request_uri)
+        request.set_form_data(payload: JSON.generate(payload))
+
+        http.request(request)
+      end
+
+      # def clean(thinger)
+      #   opts = {
+      #     invalid: :replace,
+      #     undef:   :replace,
+      #     replace: ''
+      #   }
+      #
+      #   thinger.encode(Encoding.find('ASCII'), opts)
+      # end
+
+    end
+  end
+end

--- a/lib/viget/deployment/deploy_notifier.rb
+++ b/lib/viget/deployment/deploy_notifier.rb
@@ -5,12 +5,11 @@ require 'json'
 module Viget
   module Deployment
     class DeployNotifier
-      attr_reader :cap, :deploy_notification_url, :deploy_notification_channel
+      attr_reader :cap, :deploy_notification_url
 
-      def initialize(cap, deploy_notification_url, deploy_notification_channel)
+      def initialize(cap, deploy_notification_url)
         @cap = cap
         @deploy_notification_url = deploy_notification_url
-        @deploy_notification_channel = deploy_notification_channel
       end
 
       def notify

--- a/lib/viget/deployment/shared/deploy_notification.rb
+++ b/lib/viget/deployment/shared/deploy_notification.rb
@@ -20,7 +20,7 @@ Capistrano::Configuration.instance.load do
           next
         end
 
-        notifier = Viget::Deployment::DeployNotifier.new(self, fetch(:deploy_notification_url), fetch(:deploy_notification_channel))
+        notifier = Viget::Deployment::DeployNotifier.new(self, fetch(:deploy_notification_url))
 
         notifier.notify
 

--- a/lib/viget/deployment/shared/deploy_notification.rb
+++ b/lib/viget/deployment/shared/deploy_notification.rb
@@ -1,0 +1,32 @@
+require 'viget/deployment/deploy_notifier'
+
+Capistrano::Configuration.instance.load do
+  after 'deploy:restart', 'deploy:notify:notification'
+
+  namespace :deploy do
+    namespace :notify do
+      def required_vars
+        [:deploy_notification_url, :deploy_notification_channel]
+      end
+
+      def missing_vars
+        required_vars.select { |k| fetch(k, nil).nil? }
+      end
+
+      desc 'Send deploy notification'
+      task :notification do
+        if missing_vars.any?
+          logger.important "Missing values for #{missing_vars.inspect}, skipping notification"
+          next
+        end
+
+        notifier = Viget::Deployment::DeployNotifier.new(self, fetch(:deploy_notification_url), fetch(:deploy_notification_channel))
+
+        notifier.notify
+
+        logger.important "Deploy notification sent to '#{fetch(:deploy_notification_channel)}'"
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
[SHEDDWEB-1253](https://support.sheddaquarium.org/browse/SHEDDWEB-1253)
Created new files that mimic the slack notification files so we can send deploy notifications to Teams with JSON object referenced in [INF-1331](https://support.sheddaquarium.org/browse/INF-1331). 
Commented out slack notification require in common.rb
Modified post method to send payload as JSON 
Modified payload according to Microsoft workflow 
