### PR TITLE
Upgrade whenever gem to 0.9.0 for compatibility with Ruby 3.4.2

### DIFF
--- a/lib/viget/deployment/version.rb
+++ b/lib/viget/deployment/version.rb
@@ -1,5 +1,5 @@
 module Viget
   module Deployment
-    VERSION = '2.0.0'
+    VERSION = '2.0.1'
   end
 end

--- a/viget-deployment.gemspec
+++ b/viget-deployment.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'capistrano', '~> 2.15.0'
-  gem.add_dependency 'whenever',   '~> 0.8.0'
+  gem.add_dependency 'whenever',   '~> 0.9.0'
 end


### PR DESCRIPTION
# Problem
Version of "whenever" gem was not working with Ruby 3.4.2

# Solution
Changed version of whenever gem from 0.8.0 to 0.9.0